### PR TITLE
Compatibility fixes for python2 and local versions

### DIFF
--- a/better_setuptools_git_version.py
+++ b/better_setuptools_git_version.py
@@ -3,20 +3,33 @@ import subprocess
 import collections
 
 
+def _get_command_output(command):
+    """ Compatibility wrapper for grabbing process output across multiple python versions. """
+
+    # python2.7 versions lack _get_command_output, so we'll emulate it by using check_output
+    # and ignoring the process' return status
+    try:
+        output = subprocess.check_output(command, shell=True)
+    except subprocess.CalledProcessError as e:
+        output = e.output
+
+    return output.strip()
+
+
 def get_tag():
     """Return the last tag for the git repository reachable from HEAD."""
     # another possible option is: 'git tag --merged | sort -V | tail -n1'
-    return subprocess.getoutput("git tag --sort=version:refname --merged | tail -n1")
+    return _get_command_output("git tag --sort=version:refname --merged | tail -n1")
 
 
 def get_tag_commit_sha(tag):
     """Return the commit that the tag is pointing to."""
-    return subprocess.getoutput("git rev-list -n 1 {tag}".format(tag=tag))
+    return _get_command_output("git rev-list -n 1 {tag}".format(tag=tag))
 
 
 def is_dirty():
     """Return True or False depending on whether the working tree is dirty (considers untracked files as well)"""
-    return len(subprocess.getoutput("git status -s")) != 0
+    return len(_get_command_output("git status -s")) != 0
 
 
 def is_head_at_tag(tag):
@@ -26,7 +39,7 @@ def is_head_at_tag(tag):
 
 def get_head_sha():
     """Return the sha key of HEAD."""
-    return subprocess.getoutput('git rev-parse HEAD')
+    return _get_command_output('git rev-parse HEAD')
 
 
 def get_version(template="{tag}.dev{sha}", starting_version="0.1.0"):

--- a/better_setuptools_git_version.py
+++ b/better_setuptools_git_version.py
@@ -72,7 +72,8 @@ def get_version(template="{tag}.dev{sha}", starting_version="0.1.0"):
         version = template.format(tag=tag, sha=sha)
 
     if is_dirty():
-        version = "{version}+dirty".format(version=version)
+        separator = '.' if ('+' in version) else '+'
+        version = "{version}{separator}dirty".format(version=version, separator=separator)
 
     return version
 


### PR DESCRIPTION
Hopefully you don't mind a pull request. I have a couple of things here:

- Fixing compatibility with Python2, since we still have a little while until Py2 is EOL'd, and the project README has python2 in its badge. :)
- Avoids adding multiple `+` symbols to the version number if a local version is specified.

I'd love a release with these fixes, if you're up for it and don't mind. :)