### PR TITLE
Remove dependency on tail so it works on windows

### DIFF
--- a/better_setuptools_git_version.py
+++ b/better_setuptools_git_version.py
@@ -6,7 +6,7 @@ import collections
 def get_tag():
     """Return the last tag for the git repository reachable from HEAD."""
     # another possible option is: 'git tag --merged | sort -V | tail -n1'
-    return subprocess.getoutput("git tag --sort=version:refname --merged | tail -n1")
+    return subprocess.getoutput("git tag --sort=version:refname --merged ").split('\n')[-1].strip()
 
 
 def get_tag_commit_sha(tag):


### PR DESCRIPTION
Pull the last line from gits output using python code instead of the shell command tail so that windows people can use it too!